### PR TITLE
fix: remove invalid commit_types field from release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -11,16 +11,3 @@ semver_check = true
 [changelog]
 # Use conventional commits standard
 conventional_commits = true
-# Include all commit types in changelog
-commit_types = [
-    "feat",
-    "fix",
-    "perf",
-    "refactor",
-    "style",
-    "test",
-    "chore",
-    "docs",
-    "build",
-    "ci"
-]


### PR DESCRIPTION
## Problem

The release-plz workflow is failing with a TOML parse error:
```
unknown field commit_types, expected one of header, body, trim, 
commit_preprocessors, sort_commits, link_parsers, commit_parsers, 
protect_breaking_commits, tag_pattern
```

## Solution

Remove the invalid `commit_types` field from the `[changelog]` section in `release-plz.toml`.

The field is not supported by release-plz. Conventional commits are already enabled via `conventional_commits = true`.

## Testing

- [x] Configuration is valid TOML
- [x] Follows release-plz documentation

Closes the release-plz workflow failure.