### PR TITLE
fix: remove invalid changelog section from release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,13 +1,9 @@
 [workspace]
 # Enable changelog updates
 changelog_update = true
-# Use conventional commits for changelog generation
+# Create git releases
 git_release_enable = true
 # Create git tags for releases
 git_tag_enable = true
 # Use semantic versioning
 semver_check = true
-
-[changelog]
-# Use conventional commits standard
-conventional_commits = true


### PR DESCRIPTION
## Problem

Release-plz is still failing with TOML parse error:
```
unknown field 'conventional_commits', expected one of header, body, trim, 
commit_preprocessors, sort_commits, link_parsers, commit_parsers, 
protect_breaking_commits, tag_pattern
```

## Root Cause

The `[changelog]` section with `conventional_commits = true` is invalid. Release-plz uses conventional commits by default from git commit history - it doesn't need to be configured.

## Solution

- Removed the entire `[changelog]` section
- Kept only valid workspace configuration options
- release-plz will automatically detect conventional commits from git history

## Testing

- [x] Configuration is valid TOML
- [x] Only includes documented release-plz workspace options

This should finally fix the release-plz workflow.