### PR TITLE
fix: reset version to 0.0.0 to bootstrap release-plz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "files-sdk"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2024"
 authors = ["Josh Rotenberg <josh@rotenberg.io>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Problem

release-plz workflow succeeded but didn't create a release PR because:
- No git tags exist (first release)
- Version is already 0.1.0
- release-plz reports: "repository is already up-to-date"

## Solution

Reset version to 0.0.0 so release-plz can:
1. Detect the feat: commits since project start
2. Bump version to 0.1.0 (or higher based on commits)
3. Generate changelog
4. Create release PR

## After Merge

release-plz will create a PR bumping 0.0.0 → 0.1.0+ with full changelog.