### PR TITLE
docs: streamline README with concise examples and API coverage table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "files-sdk"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "files-sdk"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2024"
 authors = ["Josh Rotenberg <josh@rotenberg.io>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Changes

Cleaned up README to be more succinct and fact-focused:

- Removed marketing language, kept technical facts
- Added comprehensive examples section:
  - File operations (upload, copy, move, delete)
  - User management (list, get, create, update)
  - File sharing (bundles, share links)
  - Automation workflows
  - Error handling patterns
  - Tracing setup
- Added API coverage table showing 288 endpoints across modules
- Removed verbose highlights section
- Streamlined installation and quick start
- Kept error types reference
- Removed development status (not needed for public repo)

README is now 50% shorter while containing more useful, actionable information.