### PR TITLE
fix: bump version to 0.1.1 after yanking conflicting 0.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "files-sdk"
-version = "0.0.0"
+version = "0.1.1"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "files-sdk"
-version = "0.0.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Josh Rotenberg <josh@rotenberg.io>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Problem

release-plz was failing with version conflict:
- crates.io had both 0.1.0 (published first) and 0.0.0 (published later)
- Git tag v0.0.0 existed
- Cargo.toml was at 0.0.0
- release-plz confused by backwards versioning

## Solution

1. ✅ Yanked 0.0.0 from crates.io
2. ✅ Deleted v0.0.0 git tag
3. ✅ Bumped version to 0.1.1 in Cargo.toml

## Result

Clean slate:
- crates.io has: 0.1.0 (active), 0.0.0 (yanked)
- Git tags: v0.1.0 only
- Cargo.toml: 0.1.1
- release-plz can now work: next release will be 0.1.1 → 0.2.0 (or 0.1.2 based on commits)