### PR TITLE
feat: add URL encoding for file paths with special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,20 @@ RUST_LOG=files_sdk=debug cargo run
 
 **Total: 288 endpoints across 90 handlers**
 
+## Path Encoding & Special Characters
+
+The SDK automatically handles special characters in file paths:
+
+```rust
+// These all work correctly - paths are automatically URL-encoded
+handler.upload_file("/my folder/file.txt", data).await?;           // spaces
+handler.upload_file("/data/file[2024].txt", data).await?;          // brackets
+handler.upload_file("/文档/测试.txt", data).await?;                 // unicode
+handler.upload_file("/files/report@#1.txt", data).await?;          // special chars
+```
+
+Paths are encoded using percent-encoding (RFC 3986), ensuring compatibility with Files.com's API regardless of the characters used in file or folder names.
+
 ## Error Types
 
 ```rust

--- a/src/files/file_actions.rs
+++ b/src/files/file_actions.rs
@@ -9,6 +9,7 @@
 //! The most important operation here is `begin_upload`, which must be called
 //! before uploading any file to Files.com.
 
+use crate::utils::encode_path;
 use crate::{FileUploadPartEntity, FilesClient, Result};
 use serde_json::json;
 
@@ -84,7 +85,8 @@ impl FileActionHandler {
             body["size"] = json!(size);
         }
 
-        let endpoint = format!("/file_actions/begin_upload{}", path);
+        let encoded_path = encode_path(path);
+        let endpoint = format!("/file_actions/begin_upload{}", encoded_path);
         let response = self.client.post_raw(&endpoint, body).await?;
 
         // Response can be a single object or an array
@@ -124,7 +126,8 @@ impl FileActionHandler {
             "mkdir_parents": mkdir_parents,
         });
 
-        let endpoint = format!("/file_actions/begin_upload{}", path);
+        let encoded_path = encode_path(path);
+        let endpoint = format!("/file_actions/begin_upload{}", encoded_path);
         let response = self.client.post_raw(&endpoint, body).await?;
 
         // Response should be an array for multipart
@@ -159,7 +162,8 @@ impl FileActionHandler {
             "destination": destination,
         });
 
-        let endpoint = format!("/file_actions/copy{}", path);
+        let encoded_path = encode_path(path);
+        let endpoint = format!("/file_actions/copy{}", encoded_path);
         self.client.post_raw(&endpoint, body).await?;
         Ok(())
     }
@@ -188,7 +192,8 @@ impl FileActionHandler {
             "destination": destination,
         });
 
-        let endpoint = format!("/file_actions/move{}", path);
+        let encoded_path = encode_path(path);
+        let endpoint = format!("/file_actions/move{}", encoded_path);
         self.client.post_raw(&endpoint, body).await?;
         Ok(())
     }
@@ -216,7 +221,8 @@ impl FileActionHandler {
     /// # }
     /// ```
     pub async fn get_metadata(&self, path: &str) -> Result<crate::FileEntity> {
-        let endpoint = format!("/file_actions/metadata{}", path);
+        let encoded_path = encode_path(path);
+        let endpoint = format!("/file_actions/metadata{}", encoded_path);
         let response = self.client.post_raw(&endpoint, json!({})).await?;
         Ok(serde_json::from_value(response)?)
     }

--- a/src/files/file_comments.rs
+++ b/src/files/file_comments.rs
@@ -7,6 +7,7 @@
 //! - Delete comments
 //! - React to comments
 
+use crate::utils::encode_path;
 use crate::{FilesClient, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -69,7 +70,8 @@ impl FileCommentHandler {
     /// # }
     /// ```
     pub async fn list(&self, path: &str) -> Result<Vec<FileCommentEntity>> {
-        let endpoint = format!("/file_comments/files{}", path);
+        let encoded_path = encode_path(path);
+        let endpoint = format!("/file_comments/files{}", encoded_path);
         let response = self.client.get_raw(&endpoint).await?;
         Ok(serde_json::from_value(response)?)
     }

--- a/src/files/files.rs
+++ b/src/files/files.rs
@@ -12,6 +12,7 @@
 
 use crate::files::FileActionHandler;
 use crate::types::FileEntity;
+use crate::utils::encode_path;
 use crate::{FilesClient, Result};
 use serde_json::json;
 use std::collections::HashMap;
@@ -66,7 +67,8 @@ impl FileHandler {
     /// # }
     /// ```
     pub async fn download_file(&self, path: &str) -> Result<FileEntity> {
-        let endpoint = format!("/files{}", path);
+        let encoded_path = encode_path(path);
+        let endpoint = format!("/files{}", encoded_path);
         let response = self.client.get_raw(&endpoint).await?;
         Ok(serde_json::from_value(response)?)
     }
@@ -163,7 +165,8 @@ impl FileHandler {
         };
 
         // Stage 3: Finalize upload with Files.com
-        let endpoint = format!("/files{}", path);
+        let encoded_path = encode_path(path);
+        let endpoint = format!("/files{}", encoded_path);
 
         // Build the finalization request as form data
         let mut form = vec![("action", "end".to_string())];
@@ -232,7 +235,8 @@ impl FileHandler {
             body["priority_color"] = json!(color);
         }
 
-        let endpoint = format!("/files{}", path);
+        let encoded_path = encode_path(path);
+        let endpoint = format!("/files{}", encoded_path);
         let response = self.client.patch_raw(&endpoint, body).await?;
         Ok(serde_json::from_value(response)?)
     }
@@ -257,10 +261,11 @@ impl FileHandler {
     /// # }
     /// ```
     pub async fn delete_file(&self, path: &str, recursive: bool) -> Result<()> {
+        let encoded_path = encode_path(path);
         let endpoint = if recursive {
-            format!("/files{}?recursive=true", path)
+            format!("/files{}?recursive=true", encoded_path)
         } else {
-            format!("/files{}", path)
+            format!("/files{}", encoded_path)
         };
 
         self.client.delete_raw(&endpoint).await?;

--- a/src/files/folders.rs
+++ b/src/files/folders.rs
@@ -41,6 +41,7 @@
 //! # }
 //! ```
 
+use crate::utils::encode_path;
 use crate::{FileEntity, FilesClient, PaginationInfo, Result};
 use serde_json::json;
 
@@ -107,7 +108,8 @@ impl FolderHandler {
         per_page: Option<i32>,
         cursor: Option<String>,
     ) -> Result<(Vec<FileEntity>, PaginationInfo)> {
-        let mut endpoint = format!("/folders{}", path);
+        let encoded_path = encode_path(path);
+        let mut endpoint = format!("/folders{}", encoded_path);
         let mut query_params = Vec::new();
 
         if let Some(per_page) = per_page {
@@ -214,7 +216,8 @@ impl FolderHandler {
             "mkdir_parents": mkdir_parents,
         });
 
-        let endpoint = format!("/folders{}", path);
+        let encoded_path = encode_path(path);
+        let endpoint = format!("/folders{}", encoded_path);
         let response = self.client.post_raw(&endpoint, body).await?;
         Ok(serde_json::from_value(response)?)
     }
@@ -239,10 +242,11 @@ impl FolderHandler {
     /// # }
     /// ```
     pub async fn delete_folder(&self, path: &str, recursive: bool) -> Result<()> {
+        let encoded_path = encode_path(path);
         let endpoint = if recursive {
-            format!("/folders{}?recursive=true", path)
+            format!("/folders{}?recursive=true", encoded_path)
         } else {
-            format!("/folders{}", path)
+            format!("/folders{}", encoded_path)
         };
 
         self.client.delete_raw(&endpoint).await?;
@@ -276,7 +280,8 @@ impl FolderHandler {
         search: &str,
         per_page: Option<i32>,
     ) -> Result<(Vec<FileEntity>, PaginationInfo)> {
-        let mut endpoint = format!("/folders{}?search={}", path, search);
+        let encoded_path = encode_path(path);
+        let mut endpoint = format!("/folders{}?search={}", encoded_path, search);
 
         if let Some(per_page) = per_page {
             endpoint.push_str(&format!("&per_page={}", per_page));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@
 // Core modules
 pub mod client;
 pub mod types;
+pub mod utils;
 
 // Domain modules
 pub mod admin;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,166 @@
+//! Utility functions for the Files.com SDK
+//!
+//! This module provides common utility functions used throughout the SDK,
+//! including path encoding, URL construction, and other helpers.
+
+/// Encodes a file path for safe use in URLs
+///
+/// Files.com paths may contain special characters (spaces, brackets, unicode, etc.)
+/// that need to be properly URL-encoded. This function:
+/// - Splits the path by `/` to preserve directory structure
+/// - Percent-encodes each path segment individually (using %20 for spaces, not +)
+/// - Rejoins with `/` separators
+///
+/// # Arguments
+///
+/// * `path` - The file or folder path to encode
+///
+/// # Returns
+///
+/// A URL-safe encoded path string
+///
+/// # Examples
+///
+/// ```
+/// use files_sdk::utils::encode_path;
+///
+/// assert_eq!(encode_path("/my folder/file.txt"), "/my%20folder/file.txt");
+/// assert_eq!(encode_path("/data/file[2024].txt"), "/data/file%5B2024%5D.txt");
+/// assert_eq!(encode_path("/文档/файл.txt"), "/%E6%96%87%E6%A1%A3/%D1%84%D0%B0%D0%B9%D0%BB.txt");
+/// ```
+pub fn encode_path(path: &str) -> String {
+    // Handle empty or root path
+    if path.is_empty() || path == "/" {
+        return path.to_string();
+    }
+
+    // Split by '/', encode each segment, then rejoin
+    let segments: Vec<String> = path
+        .split('/')
+        .map(|segment| {
+            if segment.is_empty() {
+                // Preserve empty segments (leading/trailing slashes)
+                segment.to_string()
+            } else {
+                // Percent-encode the segment
+                // We use a simple manual approach to ensure %20 for spaces (not +)
+                percent_encode(segment)
+            }
+        })
+        .collect();
+
+    segments.join("/")
+}
+
+/// Percent-encodes a string for use in URL paths
+///
+/// Unlike form encoding which uses + for spaces, this uses %20 for spaces
+/// and encodes all non-alphanumeric characters except: - _ . ~
+///
+/// This follows RFC 3986 unreserved characters
+fn percent_encode(s: &str) -> String {
+    let mut encoded = String::new();
+
+    for byte in s.bytes() {
+        match byte {
+            // Unreserved characters (RFC 3986)
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(byte as char);
+            }
+            // Everything else gets percent-encoded
+            _ => {
+                encoded.push_str(&format!("%{:02X}", byte));
+            }
+        }
+    }
+
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_simple_path() {
+        assert_eq!(encode_path("/simple/path.txt"), "/simple/path.txt");
+    }
+
+    #[test]
+    fn test_encode_path_with_spaces() {
+        assert_eq!(
+            encode_path("/my folder/my file.txt"),
+            "/my%20folder/my%20file.txt"
+        );
+    }
+
+    #[test]
+    fn test_encode_path_with_brackets() {
+        assert_eq!(
+            encode_path("/data/file[2024].txt"),
+            "/data/file%5B2024%5D.txt"
+        );
+    }
+
+    #[test]
+    fn test_encode_path_with_unicode() {
+        // Chinese characters
+        assert_eq!(
+            encode_path("/文档/测试.txt"),
+            "/%E6%96%87%E6%A1%A3/%E6%B5%8B%E8%AF%95.txt"
+        );
+
+        // Cyrillic characters
+        assert_eq!(
+            encode_path("/папка/файл.txt"),
+            "/%D0%BF%D0%B0%D0%BF%D0%BA%D0%B0/%D1%84%D0%B0%D0%B9%D0%BB.txt"
+        );
+    }
+
+    #[test]
+    fn test_encode_path_with_quotes() {
+        assert_eq!(
+            encode_path("/\"quoted\"/file.txt"),
+            "/%22quoted%22/file.txt"
+        );
+    }
+
+    #[test]
+    fn test_encode_path_with_special_chars() {
+        assert_eq!(encode_path("/data/file@#$.txt"), "/data/file%40%23%24.txt");
+    }
+
+    #[test]
+    fn test_encode_empty_path() {
+        assert_eq!(encode_path(""), "");
+    }
+
+    #[test]
+    fn test_encode_root_path() {
+        assert_eq!(encode_path("/"), "/");
+    }
+
+    #[test]
+    fn test_encode_path_preserves_leading_slash() {
+        assert_eq!(encode_path("/folder/file"), "/folder/file");
+    }
+
+    #[test]
+    fn test_encode_path_without_leading_slash() {
+        assert_eq!(encode_path("folder/file"), "folder/file");
+    }
+
+    #[test]
+    fn test_encode_path_with_trailing_slash() {
+        assert_eq!(encode_path("/folder/"), "/folder/");
+    }
+
+    #[test]
+    fn test_encode_complex_path() {
+        // Combination of spaces, brackets, and unicode
+        assert_eq!(
+            encode_path("/my folder/data [2024]/文档.txt"),
+            "/my%20folder/data%20%5B2024%5D/%E6%96%87%E6%A1%A3.txt"
+        );
+    }
+}

--- a/tests/real/files/mod.rs
+++ b/tests/real/files/mod.rs
@@ -6,3 +6,4 @@ mod file_comments;
 mod files;
 mod files_comprehensive;
 mod folders;
+mod special_characters;

--- a/tests/real/files/special_characters.rs
+++ b/tests/real/files/special_characters.rs
@@ -1,0 +1,238 @@
+//! Integration tests for files with special characters in paths
+//!
+//! These tests verify that the SDK properly handles file paths containing:
+//! - Spaces
+//! - Brackets
+//! - Unicode characters
+//! - Quotes and special symbols
+
+use files_sdk::{FileHandler, FolderHandler};
+
+use crate::real::{cleanup_file, get_test_client};
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn test_file_with_spaces() {
+    let client = get_test_client();
+    let handler = FileHandler::new(client.clone());
+
+    let path = "/integration-tests/file with spaces.txt";
+    let data = b"Testing file with spaces in path";
+
+    // Upload file with spaces in path
+    let result = handler.upload_file(path, data).await;
+    assert!(
+        result.is_ok(),
+        "Failed to upload file with spaces: {:?}",
+        result.err()
+    );
+
+    // Verify we can download it
+    let file = handler.download_file(path).await;
+    assert!(
+        file.is_ok(),
+        "Failed to download file with spaces: {:?}",
+        file.err()
+    );
+
+    // Cleanup
+    cleanup_file(&client, path).await;
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn test_file_with_brackets() {
+    let client = get_test_client();
+    let handler = FileHandler::new(client.clone());
+
+    let path = "/integration-tests/data[2024].txt";
+    let data = b"Testing file with brackets";
+
+    // Upload file with brackets
+    let result = handler.upload_file(path, data).await;
+    assert!(
+        result.is_ok(),
+        "Failed to upload file with brackets: {:?}",
+        result.err()
+    );
+
+    // Verify we can download it
+    let file = handler.download_file(path).await;
+    assert!(
+        file.is_ok(),
+        "Failed to download file with brackets: {:?}",
+        file.err()
+    );
+
+    // Cleanup
+    cleanup_file(&client, path).await;
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn test_file_with_unicode() {
+    let client = get_test_client();
+    let handler = FileHandler::new(client.clone());
+
+    // Chinese characters
+    let path = "/integration-tests/测试文件.txt";
+    let data = b"Testing file with Chinese characters";
+
+    let result = handler.upload_file(path, data).await;
+    assert!(
+        result.is_ok(),
+        "Failed to upload file with unicode: {:?}",
+        result.err()
+    );
+
+    // Verify we can download it
+    let file = handler.download_file(path).await;
+    assert!(
+        file.is_ok(),
+        "Failed to download file with unicode: {:?}",
+        file.err()
+    );
+
+    // Cleanup
+    cleanup_file(&client, path).await;
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn test_file_with_special_chars() {
+    let client = get_test_client();
+    let handler = FileHandler::new(client.clone());
+
+    let path = "/integration-tests/file@test#data.txt";
+    let data = b"Testing file with special characters";
+
+    let result = handler.upload_file(path, data).await;
+    assert!(
+        result.is_ok(),
+        "Failed to upload file with special chars: {:?}",
+        result.err()
+    );
+
+    // Verify we can download it
+    let file = handler.download_file(path).await;
+    assert!(
+        file.is_ok(),
+        "Failed to download file with special chars: {:?}",
+        file.err()
+    );
+
+    // Cleanup
+    cleanup_file(&client, path).await;
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn test_folder_with_spaces() {
+    let client = get_test_client();
+    let folder_handler = FolderHandler::new(client.clone());
+
+    let path = "/integration-tests/folder with spaces";
+
+    // Create folder with spaces
+    let result = folder_handler.create_folder(path, true).await;
+    assert!(
+        result.is_ok(),
+        "Failed to create folder with spaces: {:?}",
+        result.err()
+    );
+
+    // List the folder
+    let (files, _) = folder_handler.list_folder(path, None, None).await.unwrap();
+    assert_eq!(files.len(), 0, "Newly created folder should be empty");
+
+    // Cleanup
+    let _ = folder_handler.delete_folder(path, false).await;
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn test_complex_path() {
+    let client = get_test_client();
+    let handler = FileHandler::new(client.clone());
+
+    // Combination of spaces, brackets, and special chars
+    let path = "/integration-tests/my folder/data [2024]/report#1.txt";
+    let data = b"Testing complex path with multiple special characters";
+
+    let result = handler.upload_file(path, data).await;
+    assert!(
+        result.is_ok(),
+        "Failed to upload file with complex path: {:?}",
+        result.err()
+    );
+
+    // Verify we can download it
+    let file = handler.download_file(path).await;
+    assert!(
+        file.is_ok(),
+        "Failed to download file with complex path: {:?}",
+        file.err()
+    );
+
+    // Cleanup
+    cleanup_file(&client, path).await;
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn test_file_copy_with_special_chars() {
+    let client = get_test_client();
+    let handler = FileHandler::new(client.clone());
+
+    let source = "/integration-tests/source file.txt";
+    let dest = "/integration-tests/dest [copy].txt";
+    let data = b"Testing copy with special chars";
+
+    // Upload source file
+    handler.upload_file(source, data).await.unwrap();
+
+    // Copy to destination with special chars
+    let result = handler.copy_file(source, dest).await;
+    assert!(
+        result.is_ok(),
+        "Failed to copy file with special chars: {:?}",
+        result.err()
+    );
+
+    // Verify destination exists
+    let file = handler.download_file(dest).await;
+    assert!(file.is_ok(), "Copied file with special chars not found");
+
+    // Cleanup
+    cleanup_file(&client, source).await;
+    cleanup_file(&client, dest).await;
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn test_file_move_with_special_chars() {
+    let client = get_test_client();
+    let handler = FileHandler::new(client.clone());
+
+    let source = "/integration-tests/move source.txt";
+    let dest = "/integration-tests/moved [file].txt";
+    let data = b"Testing move with special chars";
+
+    // Upload source file
+    handler.upload_file(source, data).await.unwrap();
+
+    // Move to destination with special chars
+    let result = handler.move_file(source, dest).await;
+    assert!(
+        result.is_ok(),
+        "Failed to move file with special chars: {:?}",
+        result.err()
+    );
+
+    // Verify destination exists
+    let file = handler.download_file(dest).await;
+    assert!(file.is_ok(), "Moved file with special chars not found");
+
+    // Cleanup
+    cleanup_file(&client, dest).await;
+}


### PR DESCRIPTION
Fixes #42

## Summary
Implements comprehensive URL encoding for file paths to handle special characters (spaces, brackets, unicode, etc.) that were causing issues in other Files.com SDKs.

## Changes
- **New utility module** (`src/utils.rs`):
  - `encode_path()` - RFC 3986 percent-encoding for path segments
  - Uses %20 for spaces (not +, which is for form encoding)
  - Preserves path structure by encoding segments individually
  
- **Applied encoding to all file path handlers**:
  - `FileHandler` - download, upload, update, delete
  - `FolderHandler` - list, create, delete, search
  - `FileActionHandler` - begin_upload, copy, move, metadata
  - `FileCommentHandler` - list comments

- **Comprehensive testing**:
  - 12 unit tests for path encoding
  - 8 integration tests for real API with special characters
  - Tests cover: spaces, brackets, unicode, special chars, complex paths

- **Documentation**:
  - Added "Path Encoding & Special Characters" section to README
  - Examples showing automatic encoding behavior
  - RFC 3986 compliance noted

## Evidence from Other SDKs
Based on analysis of Files.com SDK issues:
- Ruby SDK #21: Files with spaces fail
- .NET SDK: Brackets in filenames cause 400 errors
- Multiple SDKs have unicode/special character issues

## Testing
```bash
# All tests pass
cargo test --lib --all-features
cargo clippy --all-targets --all-features -- -D warnings

# Integration tests (with FILES_API_KEY)
cargo test --test real --features integration-tests
```

## Examples
```rust
// All of these now work correctly:
handler.upload_file("/my folder/file.txt", data).await?;           // spaces
handler.upload_file("/data/file[2024].txt", data).await?;          // brackets
handler.upload_file("/文档/测试.txt", data).await?;                 // unicode
handler.upload_file("/files/report@#1.txt", data).await?;          // special chars
```