### PR TITLE
feat: add auto-paginating stream iterators for list operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,8 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 name = "files-sdk"
 version = "0.2.0"
 dependencies = [
+ "async-stream",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ thiserror = "2.0"
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1", optional = true }
 url = "2.5.7"
+futures = "0.3"
+async-stream = "0.3"
 
 [dev-dependencies]
 tokio-test = "0.4"


### PR DESCRIPTION
## Overview

Adds memory-efficient streaming pagination for list operations, addressing common pagination confusion found in other Files.com SDKs (Python SDK #1, Ruby SDK pagination issues).

Closes #45

## Changes

### New Dependencies
- ```futures = "0.3"``` - Stream utilities
- ```async-stream = "0.3"``` - Async stream macros

### FolderHandler::list_stream()
```rust
let stream = handler.list_stream("/uploads", Some(100));
tokio::pin!(stream);

while let Some(file) = stream.next().await {
    let file = file?;
    println!("{}", file.path.unwrap_or_default());
}
```

- Automatically handles pagination behind the scenes
- Configurable page size (default 1000)
- Yields individual FileEntity items as fetched
- Memory-efficient for large directories

### UserHandler::list_stream()
```rust
let stream = handler.list_stream(Some(50));
tokio::pin!(stream);

while let Some(user) = stream.next().await {
    let user = user?;
    println!("{}", user.username.unwrap_or_default());
}
```

Same streaming pattern for user lists.

### README: Comprehensive Pagination Guide

Three approaches documented with usage guidance:

**Manual Pagination** - Fine-grained control, "Load More" UI:
```rust
let (files, pagination) = handler.list_folder("/", Some(100), None).await?;
if let Some(cursor) = pagination.cursor_next {
    let (more, _) = handler.list_folder("/", Some(100), Some(cursor)).await?;
}
```

**Auto-Pagination** - Simple cases, collect all at once:
```rust
let all_files = handler.list_folder_all("/uploads").await?;
```

**Streaming** - Large datasets, real-time processing:
```rust
let stream = handler.list_stream("/uploads", Some(100));
let files: Vec<_> = stream.try_collect().await?; // or iterate
```

## Testing
- ✅ 76 doc tests passing
- ✅ 72 unit tests passing
- ✅ 2 new integration tests:
  - ```test_folder_list_stream``` - validates pagination with small page size
  - ```test_folder_list_stream_collect``` - compares stream with list_folder_all

## Design Decisions

1. **Stream requires pinning**: Using ```tokio::pin!(stream)``` macro per async-stream requirements
2. **Default page size 1000**: Balances API calls vs memory usage
3. **FolderHandler + UserHandler first**: Most commonly paginated operations; pattern can extend to other handlers
4. **Three approaches**: Provides flexibility for different use cases without prescribing one "right" way

## Benefits
1. **Solves Python SDK issue #1**: No more manual pagination confusion
2. **Memory-efficient**: Process large result sets without loading all into memory
3. **Flexible**: Manual, auto-collect, or streaming - choose based on needs
4. **Idiomatic Rust**: Uses futures::Stream trait, integrates with ecosystem tools