### PR TITLE
feat: add User-Agent and Content-Type headers to API requests

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -15,6 +15,10 @@ use std::time::Duration;
 #[cfg(feature = "tracing")]
 use tracing::{debug, error, instrument, warn};
 
+/// User-Agent header value
+/// Format: "Files.com Rust SDK {version}"
+const USER_AGENT: &str = concat!("Files.com Rust SDK ", env!("CARGO_PKG_VERSION"));
+
 /// Builder for constructing a FilesClient with custom configuration
 ///
 /// Provides a fluent interface for configuring API credentials, base URL, timeouts,
@@ -174,6 +178,7 @@ impl FilesClient {
             .client
             .get(&url)
             .header("X-FilesAPI-Key", &self.inner.api_key)
+            .header("User-Agent", USER_AGENT)
             .send()
             .await?;
 
@@ -208,6 +213,8 @@ impl FilesClient {
             .client
             .post(&url)
             .header("X-FilesAPI-Key", &self.inner.api_key)
+            .header("User-Agent", USER_AGENT)
+            .header("Content-Type", "application/json")
             .json(&body)
             .send()
             .await?;
@@ -243,6 +250,8 @@ impl FilesClient {
             .client
             .patch(&url)
             .header("X-FilesAPI-Key", &self.inner.api_key)
+            .header("User-Agent", USER_AGENT)
+            .header("Content-Type", "application/json")
             .json(&body)
             .send()
             .await?;
@@ -274,6 +283,7 @@ impl FilesClient {
             .client
             .delete(&url)
             .header("X-FilesAPI-Key", &self.inner.api_key)
+            .header("User-Agent", USER_AGENT)
             .send()
             .await?;
 
@@ -301,6 +311,7 @@ impl FilesClient {
             .client
             .post(&url)
             .header("X-FilesAPI-Key", &self.inner.api_key)
+            .header("User-Agent", USER_AGENT)
             .form(&form)
             .send()
             .await?;


### PR DESCRIPTION
Closes #51

Adds standard HTTP headers following the Python SDK pattern:

- **User-Agent**: `Files.com Rust SDK {version}` (compile-time version from Cargo.toml)
- **Content-Type**: `application/json` on POST/PATCH requests

Headers added to all HTTP methods:
- GET: User-Agent
- POST: User-Agent + Content-Type
- PATCH: User-Agent + Content-Type  
- DELETE: User-Agent
- post_form: User-Agent

Implementation uses `concat!()` macro to embed version at compile-time:
```rust
const USER_AGENT: &str = concat!("Files.com Rust SDK ", env!("CARGO_PKG_VERSION"));
```

All tests passing (72 unit tests, clippy clean).