### PR TITLE
feat: polish streaming API with documentation and optimizations (Phase 3)

### DIFF
--- a/examples/streaming.rs
+++ b/examples/streaming.rs
@@ -1,0 +1,168 @@
+//! Streaming file operations with progress tracking
+//!
+//! This example demonstrates how to use the streaming API for memory-efficient
+//! file uploads and downloads with optional progress tracking.
+//!
+//! Run with:
+//! ```bash
+//! FILES_API_KEY=your-key cargo run --example streaming
+//! ```
+
+use files_sdk::FilesClient;
+use files_sdk::files::FileHandler;
+use files_sdk::progress::{Progress, ProgressCallback};
+use std::env;
+use std::io::Write;
+use std::sync::Arc;
+
+use std::time::Instant;
+
+/// Custom progress tracker that displays transfer rate and ETA
+struct ProgressTracker {
+    start: Instant,
+}
+
+impl ProgressTracker {
+    fn new() -> Self {
+        Self {
+            start: Instant::now(),
+        }
+    }
+}
+
+impl ProgressCallback for ProgressTracker {
+    fn on_progress(&self, progress: &Progress) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.start).as_secs_f64();
+
+        // Calculate overall transfer rate
+        let rate_mbps = if elapsed > 0.0 {
+            (progress.bytes_transferred as f64 / elapsed) / (1024.0 * 1024.0)
+        } else {
+            0.0
+        };
+
+        if let Some(total) = progress.total_bytes {
+            let pct = progress.percentage().unwrap_or(0.0);
+            let remaining_bytes = total.saturating_sub(progress.bytes_transferred);
+            let eta_secs = if rate_mbps > 0.0 {
+                remaining_bytes as f64 / (rate_mbps * 1024.0 * 1024.0)
+            } else {
+                0.0
+            };
+
+            print!(
+                "\r[{:>6.1}%] {:.2} MB / {:.2} MB @ {:.2} MB/s | ETA: {:.0}s    ",
+                pct,
+                progress.bytes_transferred as f64 / (1024.0 * 1024.0),
+                total as f64 / (1024.0 * 1024.0),
+                rate_mbps,
+                eta_secs
+            );
+        } else {
+            print!(
+                "\r{:.2} MB @ {:.2} MB/s    ",
+                progress.bytes_transferred as f64 / (1024.0 * 1024.0),
+                rate_mbps
+            );
+        }
+        std::io::stdout().flush().unwrap();
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get API key from environment
+    let api_key = env::var("FILES_API_KEY").expect("FILES_API_KEY environment variable not set");
+
+    // Create client
+    let client = FilesClient::builder().api_key(api_key).build()?;
+
+    let handler = FileHandler::new(client.clone());
+
+    println!("=== Files.com Streaming API Examples ===\n");
+
+    // Example 1: Upload with progress tracking
+    println!("1. Uploading file with progress tracking...");
+    let upload_path = "/tmp/streaming-example-upload.bin";
+    let remote_path = "/streaming-test-upload.bin";
+
+    // Create a 5MB test file
+    println!("   Creating 5MB test file...");
+    let size = 5 * 1024 * 1024; // 5MB
+    let mut file = std::fs::File::create(upload_path)?;
+    let chunk = vec![0xAB; 1024]; // 1KB chunk
+    for _ in 0..(size / 1024) {
+        file.write_all(&chunk)?;
+    }
+    drop(file);
+
+    // Upload with progress
+    println!("   Uploading...");
+    let progress_tracker = Arc::new(ProgressTracker::new());
+    let file = tokio::fs::File::open(upload_path).await?;
+
+    handler
+        .upload_stream(
+            remote_path,
+            file,
+            Some(size as i64),
+            Some(progress_tracker.clone()),
+        )
+        .await?;
+
+    println!("\n   Upload complete!");
+
+    // Example 2: Download with progress tracking
+    println!("\n2. Downloading file with progress tracking...");
+    let download_path = "/tmp/streaming-example-download.bin";
+
+    println!("   Downloading...");
+    let progress_tracker = Arc::new(ProgressTracker::new());
+    let mut file = tokio::fs::File::create(download_path).await?;
+
+    handler
+        .download_stream(remote_path, &mut file, Some(progress_tracker.clone()))
+        .await?;
+
+    println!("\n   Download complete!");
+
+    // Example 3: Upload from memory (Cursor)
+    println!("\n3. Uploading from memory buffer...");
+    let data = b"Hello from streaming API! This is a test of uploading from memory.";
+    let cursor = std::io::Cursor::new(data.to_vec());
+    let remote_path_2 = "/streaming-test-memory.txt";
+
+    handler
+        .upload_stream(remote_path_2, cursor, Some(data.len() as i64), None)
+        .await?;
+
+    println!("   Upload from memory complete!");
+
+    // Example 4: Download to memory
+    println!("\n4. Downloading to memory buffer...");
+    let mut buffer = Vec::new();
+
+    handler
+        .download_stream(remote_path_2, &mut buffer, None)
+        .await?;
+
+    println!("   Downloaded {} bytes", buffer.len());
+    println!(
+        "   Content: {}",
+        String::from_utf8_lossy(&buffer[..buffer.len().min(50)])
+    );
+
+    // Cleanup
+    println!("\n5. Cleaning up test files...");
+    handler.delete_file(remote_path, false).await?;
+    handler.delete_file(remote_path_2, false).await?;
+    std::fs::remove_file(upload_path)?;
+    std::fs::remove_file(download_path)?;
+
+    println!("   Cleanup complete!");
+
+    println!("\n=== All examples completed successfully! ===");
+
+    Ok(())
+}

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,7 +1,85 @@
 //! Progress tracking for file operations
 //!
 //! This module provides traits and types for tracking progress during
-//! file uploads and downloads.
+//! file uploads and downloads with the streaming API.
+//!
+//! # Overview
+//!
+//! The progress tracking system consists of:
+//! - [`Progress`] - Immutable snapshot of current progress
+//! - [`ProgressCallback`] - Trait for receiving progress updates
+//! - [`PrintProgressCallback`] - Built-in stdout progress logger
+//!
+//! # Usage
+//!
+//! Progress callbacks are optional and can be passed to streaming methods
+//! like [`FileHandler::upload_stream()`](crate::files::FileHandler::upload_stream)
+//! and [`FileHandler::download_stream()`](crate::files::FileHandler::download_stream).
+//!
+//! ## Basic Example
+//!
+//! ```rust
+//! use files_sdk::progress::{Progress, ProgressCallback};
+//! use std::sync::Arc;
+//!
+//! // Simple progress tracker
+//! struct SimpleTracker;
+//!
+//! impl ProgressCallback for SimpleTracker {
+//!     fn on_progress(&self, progress: &Progress) {
+//!         if let Some(pct) = progress.percentage() {
+//!             println!("Upload: {:.1}%", pct);
+//!         }
+//!     }
+//! }
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! # use files_sdk::{FilesClient, files::FileHandler};
+//! # let client = FilesClient::builder().api_key("key").build()?;
+//! let handler = FileHandler::new(client);
+//! let callback = Arc::new(SimpleTracker);
+//!
+//! // Use with streaming upload
+//! let file = tokio::fs::File::open("large-file.bin").await?;
+//! let size = file.metadata().await?.len() as i64;
+//! handler.upload_stream("/remote/path.bin", file, Some(size), Some(callback)).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Advanced Example with State
+//!
+//! ```rust
+//! use files_sdk::progress::{Progress, ProgressCallback};
+//! use std::sync::{Arc, Mutex};
+//! use std::time::Instant;
+//!
+//! // Progress tracker with transfer rate calculation
+//! struct RateTracker {
+//!     start: Instant,
+//!     last_bytes: Arc<Mutex<u64>>,
+//! }
+//!
+//! impl RateTracker {
+//!     fn new() -> Self {
+//!         Self {
+//!             start: Instant::now(),
+//!             last_bytes: Arc::new(Mutex::new(0)),
+//!         }
+//!     }
+//! }
+//!
+//! impl ProgressCallback for RateTracker {
+//!     fn on_progress(&self, progress: &Progress) {
+//!         let elapsed = self.start.elapsed().as_secs_f64();
+//!         let rate = progress.bytes_transferred as f64 / elapsed / 1024.0 / 1024.0;
+//!
+//!         if let Some(pct) = progress.percentage() {
+//!             println!("Progress: {:.1}% @ {:.2} MB/s", pct, rate);
+//!         }
+//!     }
+//! }
+//! ```
 
 /// Progress information for a file operation
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

Implements Phase 3 of #61 - Polish and optimization for streaming API.

## Changes

### Documentation Enhancements

**Progress Module**:
- Comprehensive module-level documentation with overview
- Basic example showing simple progress tracking
- Advanced example with transfer rate calculation
- Links to related streaming methods

**Streaming Methods**:
- Detailed rustdoc for upload_stream() and download_stream()
- Multiple examples per method (basic, with progress, from any source)
- Clear argument descriptions and return values
- Cross-references between related APIs

**New Example**: examples/streaming.rs
- Real-world progress tracker with transfer rate and ETA
- Demonstrates 4 use cases:
  1. Upload file with progress tracking
  2. Download file with progress tracking
  3. Upload from memory (Cursor)
  4. Download to memory
- Shows custom ProgressCallback implementation
- Includes cleanup logic

### Performance Optimizations

**Chunk Size**: Increased from 8KB to 64KB
- Defined as STREAM_CHUNK_SIZE constant (65536 bytes)
- 8x larger = fewer syscalls, better throughput
- Documented rationale in code comments

**Buffer Pre-allocation**:
- Pre-allocate Vec with capacity when file size is known
- Reduces reallocations during streaming
- Better memory usage patterns

**Code Comments**:
- Explained why we buffer before upload (Files.com API requirement)
- Documented chunk size tradeoffs
- Added performance notes

## Testing

All tests passing:
- 75 library tests pass
- Clippy clean with -D warnings
- Example compiles and is ready to run

## Example Output

The streaming example shows:
```
[  45.2%] 2.26 MB / 5.00 MB @ 12.34 MB/s | ETA: 1s
```

## Completes

Closes #61 (all phases complete)