### PR TITLE
fix: handle empty file uploads in upload_stream

### DIFF
--- a/src/files/files.rs
+++ b/src/files/files.rs
@@ -541,8 +541,13 @@ impl FileHandler {
 
         let upload_part = &upload_parts[0];
 
+        // Special case: empty files (size=0) may not have an upload_uri
+        // In this case, we skip the upload stage and go straight to finalization
+        let is_empty_file = size == Some(0);
+
         // Stage 2: Stream file data to the provided URL with progress tracking
-        let _etag = if let Some(upload_uri) = &upload_part.upload_uri {
+        let _etag = if !is_empty_file && upload_part.upload_uri.is_some() {
+            let upload_uri = upload_part.upload_uri.as_ref().unwrap();
             // Read the stream into a buffer with progress tracking
             // Note: We read in chunks to provide progress updates, but still buffer
             // the entire file before upload. This is required by the Files.com API


### PR DESCRIPTION
## Problem

Empty files (size=0) fail to upload with "Failed to upload" error.

Discovered in files-watch example (#66) when uploading empty files:
```
✗ qwkejn - Failed to upload: /backup/docs/qwkejn
```

## Root Cause

The Files.com API doesn't provide an `upload_uri` for empty files in the `begin_upload` response. Our code was trying to upload to this non-existent URI, causing the failure.

## Solution

Added special handling for empty files (size=0):
- Skip the upload stage when `size == Some(0)`
- Go directly to finalization stage
- The API handles empty file creation during finalization

## Changes

- `src/files/files.rs`: Added `is_empty_file` check before attempting upload
- Only attempt upload if file is not empty AND has an upload_uri

## Testing

Manual testing pending - will test with files-watch example after merge.

Fixes issue reported in #66