### PR TITLE
feat: files-watch Phase 2 - Download & Bidirectional Sync

### DIFF
--- a/examples/files-watch/Cargo.toml
+++ b/examples/files-watch/Cargo.toml
@@ -21,3 +21,4 @@ glob = "0.3"
 sha2 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5"
+filetime = "0.2"

--- a/examples/files-watch/README.md
+++ b/examples/files-watch/README.md
@@ -2,14 +2,21 @@
 
 A filesystem sync daemon for Files.com, demonstrating the files-sdk-rs streaming capabilities.
 
-## Features (Phase 1)
+## Features
 
+### Phase 1 (Complete)
 - **Filesystem Watching**: Real-time monitoring of directory changes
 - **Upload-only Sync**: Automatically sync local changes to Files.com
 - **Progress Tracking**: Visual progress bars for file uploads
 - **State Management**: Track synced files to avoid redundant uploads
 - **Pattern Ignoring**: Skip files matching glob patterns
 - **Incremental Sync**: Only upload changed files
+
+### Phase 2 (Complete)
+- **Download Sync**: Sync from Files.com → Local
+- **Bidirectional Sync**: Two-way sync with conflict resolution
+- **Conflict Resolution**: Newest, largest, or manual resolution strategies
+- **Remote Change Detection**: Scan Files.com for changes
 
 ## Installation
 
@@ -73,7 +80,14 @@ cargo run -- list
 Perform a one-time sync without watching:
 
 ```bash
+# Upload only (default)
 cargo run -- sync /path/to/local/dir
+
+# Download only
+cargo run -- sync /path/to/local/dir --direction down
+
+# Bidirectional sync with conflict resolution
+cargo run -- sync /path/to/local/dir --direction both
 ```
 
 Full sync (ignore state, sync all files):
@@ -137,15 +151,11 @@ Watching for changes (Ctrl+C to stop)...
 ✓ report.pdf
 ```
 
-## Phase 1 Limitations
+## Limitations
 
-- Upload-only (no download or bidirectional sync yet)
-- Single watch config at a time
-- No daemon mode
-- No remote change detection
-- Basic conflict resolution
-
-These features will be added in Phases 2-4.
+- Single watch config at a time (Phase 3)
+- No daemon mode (Phase 3)
+- No .filesignore support (Phase 3)
 
 ## SDK Features Demonstrated
 

--- a/examples/files-watch/src/conflict.rs
+++ b/examples/files-watch/src/conflict.rs
@@ -1,0 +1,171 @@
+//! Conflict resolution for bidirectional sync
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+
+/// Represents a file that exists in both local and remote locations
+#[derive(Debug, Clone)]
+pub struct FileConflict {
+    #[allow(dead_code)]
+    pub path: String,
+    pub local_size: u64,
+    pub local_mtime: DateTime<Utc>,
+    pub remote_size: i64,
+    pub remote_mtime: DateTime<Utc>,
+}
+
+/// Resolution strategy for conflicts
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictResolution {
+    /// Use the file with the newest modification time
+    Newest,
+    /// Use the file with the largest size
+    Largest,
+    /// Skip conflicted files (require manual resolution)
+    Manual,
+}
+
+impl ConflictResolution {
+    /// Parse resolution from string
+    pub fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "newest" => Ok(Self::Newest),
+            "largest" => Ok(Self::Largest),
+            "manual" => Ok(Self::Manual),
+            _ => anyhow::bail!("Invalid conflict resolution: {}", s),
+        }
+    }
+}
+
+/// Determines which version should win in a conflict
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictWinner {
+    Local,
+    Remote,
+    Skip,
+}
+
+impl FileConflict {
+    /// Resolve the conflict based on the given strategy
+    pub fn resolve(&self, strategy: ConflictResolution) -> ConflictWinner {
+        match strategy {
+            ConflictResolution::Newest => {
+                if self.local_mtime > self.remote_mtime {
+                    ConflictWinner::Local
+                } else if self.remote_mtime > self.local_mtime {
+                    ConflictWinner::Remote
+                } else {
+                    // Same timestamp - use size as tiebreaker
+                    if self.local_size > self.remote_size as u64 {
+                        ConflictWinner::Local
+                    } else {
+                        ConflictWinner::Remote
+                    }
+                }
+            }
+            ConflictResolution::Largest => {
+                if self.local_size > self.remote_size as u64 {
+                    ConflictWinner::Local
+                } else if (self.remote_size as u64) > self.local_size {
+                    ConflictWinner::Remote
+                } else {
+                    // Same size - use time as tiebreaker
+                    if self.local_mtime > self.remote_mtime {
+                        ConflictWinner::Local
+                    } else {
+                        ConflictWinner::Remote
+                    }
+                }
+            }
+            ConflictResolution::Manual => ConflictWinner::Skip,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_newest_local_wins() {
+        let conflict = FileConflict {
+            path: "test.txt".to_string(),
+            local_size: 100,
+            local_mtime: Utc::now(),
+            remote_size: 100,
+            remote_mtime: Utc::now() - chrono::Duration::hours(1),
+        };
+
+        assert_eq!(
+            conflict.resolve(ConflictResolution::Newest),
+            ConflictWinner::Local
+        );
+    }
+
+    #[test]
+    fn test_resolve_newest_remote_wins() {
+        let conflict = FileConflict {
+            path: "test.txt".to_string(),
+            local_size: 100,
+            local_mtime: Utc::now() - chrono::Duration::hours(1),
+            remote_size: 100,
+            remote_mtime: Utc::now(),
+        };
+
+        assert_eq!(
+            conflict.resolve(ConflictResolution::Newest),
+            ConflictWinner::Remote
+        );
+    }
+
+    #[test]
+    fn test_resolve_largest_local_wins() {
+        let now = Utc::now();
+        let conflict = FileConflict {
+            path: "test.txt".to_string(),
+            local_size: 200,
+            local_mtime: now,
+            remote_size: 100,
+            remote_mtime: now,
+        };
+
+        assert_eq!(
+            conflict.resolve(ConflictResolution::Largest),
+            ConflictWinner::Local
+        );
+    }
+
+    #[test]
+    fn test_resolve_manual_always_skips() {
+        let now = Utc::now();
+        let conflict = FileConflict {
+            path: "test.txt".to_string(),
+            local_size: 100,
+            local_mtime: now,
+            remote_size: 100,
+            remote_mtime: now,
+        };
+
+        assert_eq!(
+            conflict.resolve(ConflictResolution::Manual),
+            ConflictWinner::Skip
+        );
+    }
+
+    #[test]
+    fn test_resolution_from_str() {
+        assert_eq!(
+            ConflictResolution::from_str("newest").unwrap(),
+            ConflictResolution::Newest
+        );
+        assert_eq!(
+            ConflictResolution::from_str("largest").unwrap(),
+            ConflictResolution::Largest
+        );
+        assert_eq!(
+            ConflictResolution::from_str("manual").unwrap(),
+            ConflictResolution::Manual
+        );
+        assert!(ConflictResolution::from_str("invalid").is_err());
+    }
+}

--- a/examples/files-watch/src/main.rs
+++ b/examples/files-watch/src/main.rs
@@ -3,6 +3,7 @@
 mod cli;
 mod commands;
 mod config;
+mod conflict;
 mod progress;
 mod state;
 mod syncer;


### PR DESCRIPTION
## Overview

Phase 2 of the files-watch example implementing download and bidirectional sync capabilities.

## Features Implemented

### Download Mode
- ✅ Download files from Files.com → Local
- ✅ Stream downloads with `FileHandler::download_stream()`
- ✅ Preserve remote file modification times
- ✅ Create local directory structure as needed

### Bidirectional Sync
- ✅ Two-way sync (upload + download)
- ✅ Detect files that exist on both sides
- ✅ Detect files unique to each side
- ✅ Handle conflicts with resolution strategies

### Conflict Resolution
- ✅ **Newest wins**: Use file with latest modification time
- ✅ **Largest wins**: Use file with largest size
- ✅ **Manual**: Skip conflicted files (require user intervention)
- ✅ Configurable via `config.toml`

### Remote Change Detection
- ✅ Scan remote directory with `FolderHandler::list_folder()`
- ✅ Pagination support for large directories
- ✅ Parse remote file metadata (size, mtime)
- ✅ Compare with local state

## New Modules

- **`conflict.rs`**: Conflict detection and resolution logic
  - `FileConflict` struct
  - `ConflictResolution` enum
  - `ConflictWinner` decision logic
  - Unit tests included

## Updated Components

- **`syncer.rs`**:
  - `download_file()` - Stream download with progress
  - `scan_remote()` - List and parse remote files
  - `sync_bidirectional()` - Two-way sync with conflicts
  - `collect_local_files()` - Recursive local file scanner

- **`commands/sync.rs`**:
  - Support for `--direction up/down/both`
  - Download-only implementation
  - Bidirectional sync implementation

- **`README.md`**: Updated with Phase 2 features and usage examples

## Usage

```bash
# Upload only (Phase 1, still works)
cargo run -- sync /path/to/local/dir

# Download only (NEW)
cargo run -- sync /path/to/local/dir --direction down

# Bidirectional sync (NEW)
cargo run -- sync /path/to/local/dir --direction both
```

## Configuration

```toml
[conflict]
resolution = "newest"  # or "largest" or "manual"
```

## Dependencies Added

- `filetime = "0.2"` - For setting file modification times

## Testing

- ✅ Compiles without errors
- ✅ Clippy clean with `-D warnings`
- ✅ Formatted with `cargo fmt`
- ✅ All existing Phase 1 functionality preserved

## SDK Features Demonstrated

- `FileHandler::download_stream()` - Streaming downloads
- `FolderHandler::list_folder()` - Listing remote directories with pagination
- Progress callback support for downloads
- Async file I/O with tokio

## What's Next (Phase 3)

- Daemon mode
- .filesignore support  
- Multiple watch configs
- Incremental sync with hashing

Related: Issue #65