### PR TITLE
feat: add prelude module for common imports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@
 // Core modules
 pub mod client;
 pub mod error;
+pub mod prelude;
 pub mod progress;
 pub mod types;
 pub mod utils;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,41 @@
+//! Convenient re-exports for common types and traits
+//!
+//! This module provides a convenient way to import the most commonly used types
+//! and traits from the Files.com SDK. It follows the Rust convention of providing
+//! a `prelude` module for frequently-used items.
+//!
+//! # Usage
+//!
+//! ```rust
+//! use files_sdk::prelude::*;
+//!
+//! // Now you have access to all common types without individual imports
+//! # fn example() -> Result<()> {
+//! let client = FilesClient::builder()
+//!     .api_key("your-api-key")
+//!     .build()?;
+//!
+//! let file_handler = FileHandler::new(client.clone());
+//! # Ok(())
+//! # }
+//! ```
+
+// Core client and error types
+pub use crate::client::{FilesClient, FilesClientBuilder};
+pub use crate::error::{FilesError, Result};
+
+// Common entity types
+pub use crate::types::{FileEntity, FileUploadPartEntity, FolderEntity, PaginationInfo};
+
+// Progress tracking
+pub use crate::progress::{Progress, ProgressCallback};
+
+// Most commonly used handlers
+pub use crate::files::{FileActionHandler, FileHandler, FolderHandler};
+pub use crate::users::{ApiKeyHandler, GroupHandler, SessionHandler, UserHandler};
+
+// Sharing
+pub use crate::sharing::{BundleHandler, RequestHandler};
+
+// Automation
+pub use crate::automation::{AutomationHandler, BehaviorHandler};


### PR DESCRIPTION
Adds a convenience prelude module following standard Rust library patterns.

## Changes

### New Module: 

A curated collection of the most commonly used types and traits for easy importing:

**Core Types**:
- `FilesClient`, `FilesClientBuilder` - Client creation
- `FilesError`, `Result` - Error handling
- `FileEntity`, `FolderEntity`, `PaginationInfo` - Common entities
- `Progress`, `ProgressCallback` - Progress tracking

**Common Handlers**:
- Files: `FileHandler`, `FolderHandler`, `FileActionHandler`
- Users: `UserHandler`, `GroupHandler`, `ApiKeyHandler`, `SessionHandler`
- Sharing: `BundleHandler`, `RequestHandler`
- Automation: `AutomationHandler`, `BehaviorHandler`

## Usage

### Before (verbose imports):
```rust
use files_sdk::{FilesClient, FilesError, Result};
use files_sdk::files::{FileHandler, FolderHandler};
use files_sdk::users::{UserHandler, GroupHandler};
use files_sdk::progress::{Progress, ProgressCallback};
```

### After (clean prelude):
```rust
use files_sdk::prelude::*;

// All common types now available
```

## Benefits

1. **Reduced boilerplate** - Single import for common use cases
2. **Standard pattern** - Follows Rust conventions (tokio, serde, etc.)
3. **Better ergonomics** - Easier for new users to get started
4. **No hiding** - Still uses explicit `use` statement

## Testing

- ✅ Doc test passes
- ✅ Clippy clean
- ✅ Formatted with rustfmt

Closes #72