### PR TITLE
feat: add client-side rate limiting with governor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.11",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +250,7 @@ version = "0.3.1"
 dependencies = [
  "async-stream",
  "futures",
+ "governor",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
@@ -355,6 +376,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,9 +419,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.7+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -402,6 +431,29 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "governor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.3",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot 0.12.4",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
 
 [[package]]
 name = "h2"
@@ -421,6 +473,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -675,7 +733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -832,6 +890,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1052,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +1085,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,8 +1121,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1041,7 +1142,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1051,6 +1162,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -1183,7 +1312,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1421,6 +1550,15 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -1936,6 +2074,16 @@ name = "web-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde_path_to_error = "0.1"
 thiserror = "2.0"
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
+governor = "0.8"
 tracing = { version = "0.1", optional = true }
 url = "2.5.7"
 futures = "0.3"

--- a/examples/rate_limiting.rs
+++ b/examples/rate_limiting.rs
@@ -1,0 +1,104 @@
+//! Rate Limiting Example
+//!
+//! Demonstrates client-side rate limiting to prevent hitting Files.com API limits.
+//!
+//! Run with:
+//! ```bash
+//! FILES_API_KEY=your-key cargo run --example rate_limiting
+//! ```
+
+use files_sdk::files::FolderHandler;
+use files_sdk::{FilesClient, Result};
+use std::env;
+use std::time::{Duration, Instant};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let api_key = env::var("FILES_API_KEY").expect("FILES_API_KEY environment variable required");
+
+    println!("Files.com Rate Limiting Examples\n");
+    println!("=================================\n");
+
+    // Example 1: No rate limiting (default)
+    println!("1. No Rate Limiting (Unlimited):");
+    println!("   - All requests sent immediately");
+    println!("   - Risk of hitting API rate limits\n");
+
+    let client_unlimited = FilesClient::builder().api_key(&api_key).build()?;
+
+    let start = Instant::now();
+    make_requests(client_unlimited, 5).await?;
+    let elapsed = start.elapsed();
+
+    println!("   Completed 5 requests in {:?}", elapsed);
+    println!("   Average: {:?} per request\n", elapsed / 5);
+
+    // Example 2: Rate limited to 2 requests per second
+    println!("2. Rate Limited (2 requests/second):");
+    println!("   - Token bucket algorithm");
+    println!("   - Automatic throttling when limit reached");
+    println!("   - Prevents 429 errors\n");
+
+    let client_limited = FilesClient::builder()
+        .api_key(&api_key)
+        .rate_limit(2) // 2 requests per second
+        .build()?;
+
+    let start = Instant::now();
+    make_requests(client_limited, 5).await?;
+    let elapsed = start.elapsed();
+
+    println!("   Completed 5 requests in {:?}", elapsed);
+    println!("   Average: {:?} per request\n", elapsed / 5);
+    println!("   Note: Slower due to rate limiting (expected)\n");
+
+    // Example 3: Production configuration
+    println!("3. Production Configuration:");
+    println!("   - Rate limit: 10 requests/second");
+    println!("   - Retries: 3 attempts");
+    println!("   - Timeout: 60s");
+    println!("   - Balanced for reliability and performance\n");
+
+    let client_production = FilesClient::builder()
+        .api_key(&api_key)
+        .rate_limit(10)
+        .max_retries(3)
+        .timeout(Duration::from_secs(60))
+        .build()?;
+
+    let folder_handler = FolderHandler::new(client_production);
+    match folder_handler.list_folder("/", None, None).await {
+        Ok(_) => println!("   ✓ Successfully listed root directory with production config"),
+        Err(e) => println!("   ✗ Failed: {}", e),
+    }
+
+    println!("\nRate Limiting Behavior:");
+    println!("=======================");
+    println!("- Token bucket refills at configured rate (requests/second)");
+    println!("- Requests block if no tokens available");
+    println!("- Allows short bursts up to bucket capacity");
+    println!("- Prevents wasteful retries from 429 errors");
+    println!("- Recommended for bulk operations or high-frequency access");
+
+    Ok(())
+}
+
+/// Helper function to make multiple requests
+async fn make_requests(client: FilesClient, count: usize) -> Result<()> {
+    let folder_handler = FolderHandler::new(client);
+
+    for i in 1..=count {
+        let start = Instant::now();
+        folder_handler
+            .list_folder("/", None, Some("1".to_string()))
+            .await?;
+        println!(
+            "   Request {}/{} completed in {:?}",
+            i,
+            count,
+            start.elapsed()
+        );
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,32 @@
 //! # }
 //! ```
 //!
+//! ### Client-Side Rate Limiting
+//!
+//! Prevent hitting API rate limits by configuring client-side rate limiting:
+//!
+//! - **Token bucket algorithm**: Allows bursts while maintaining average rate
+//! - **Automatic throttling**: Requests wait until tokens are available
+//! - **Prevents 429 errors**: Proactive rather than reactive
+//!
+//! ```rust,no_run
+//! use files_sdk::FilesClient;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Limit to 10 requests per second
+//! let client = FilesClient::builder()
+//!     .api_key("your-api-key")
+//!     .rate_limit(10)
+//!     .build()?;
+//!
+//! // No rate limiting (default)
+//! let client_unlimited = FilesClient::builder()
+//!     .api_key("your-api-key")
+//!     .build()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! ### File Upload (Two-Stage Process)
 //!
 //! Files.com uses a two-stage upload process:


### PR DESCRIPTION
## Summary

Implements client-side rate limiting to prevent hitting Files.com API limits.

## Changes

- Add governor crate for token bucket rate limiting
- Add rate_limit() builder method to FilesClientBuilder
- Rate limiting applied to all HTTP methods (GET, POST, PATCH, DELETE, form)
- Add comprehensive rate limiting documentation to lib.rs
- Add examples/rate_limiting.rs demonstrating usage
- All tests passing, clippy clean

## Features

**Rate Limiting:**
- Token bucket algorithm (allows bursts while maintaining average rate)
- Automatic throttling (requests wait until tokens are available)
- Prevents 429 errors proactively
- Optional (disabled by default)

## Example

```rust
let client = FilesClient::builder()
    .api_key("your-api-key")
    .rate_limit(10)  // 10 requests per second
    .build()?;
```

## Why governor instead of tower?

We explored using tower's RateLimitLayer but it's incompatible with reqwest-middleware. Governor provides:
- Async-native rate limiting
- Token bucket algorithm
- Zero overhead when disabled
- Simple integration

See issue #75 for discussion on potentially refactoring to a pure tower-based architecture.

## Testing

- 75 unit tests passing
- Clippy clean with -D warnings
- Example demonstrates 3 configurations (unlimited, limited, production)

Closes #74