### PR TITLE
feat: type-safe enums for closed-set fields (part of #13)

### DIFF
--- a/examples/files-watch/src/syncer.rs
+++ b/examples/files-watch/src/syncer.rs
@@ -357,7 +357,7 @@ impl Syncer {
 
             for file in files {
                 // Only process actual files, not directories
-                if file.file_type.as_deref() == Some("file") {
+                if file.file_type.as_ref().is_some_and(|t| t.is_file()) {
                     if let Some(path) = &file.path {
                         let size = file.size.unwrap_or(0);
 

--- a/src/files/files.rs
+++ b/src/files/files.rs
@@ -548,8 +548,7 @@ impl FileHandler {
         // Stage 2: Stream file data to the provided URL with progress tracking
         // Note: Even for empty files (size=0), we must perform the upload stage.
         // S3 requires the Content-Length header, and the API tracks whether the upload occurred.
-        let _etag = if upload_part.upload_uri.is_some() {
-            let upload_uri = upload_part.upload_uri.as_ref().unwrap();
+        let _etag = if let Some(upload_uri) = upload_part.upload_uri.as_ref() {
             // Read the stream into a buffer with progress tracking
             // Note: We read in chunks to provide progress updates, but still buffer
             // the entire file before upload. This is required by the Files.com API

--- a/src/files/folders.rs
+++ b/src/files/folders.rs
@@ -26,8 +26,8 @@
 //! // List root directory
 //! let (files, pagination) = handler.list_folder("/", None, None).await?;
 //! for file in files {
-//!     println!("{}: {}",
-//!         file.file_type.unwrap_or_default(),
+//!     println!("{:?}: {}",
+//!         file.file_type,
 //!         file.path.unwrap_or_default());
 //! }
 //!
@@ -94,7 +94,7 @@ impl FolderHandler {
     /// let (files, pagination) = handler.list_folder("/", None, None).await?;
     ///
     /// for file in files {
-    ///     println!("{}: {}", file.file_type.unwrap_or_default(), file.path.unwrap_or_default());
+    ///     println!("{:?}: {}", file.file_type, file.path.unwrap_or_default());
     /// }
     ///
     /// if pagination.has_next() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ pub use client::{FilesClient, FilesClientBuilder};
 pub use error::{FilesError, Result};
 
 // Re-export common types
-pub use types::{FileEntity, FileUploadPartEntity, FolderEntity, PaginationInfo};
+pub use types::{EntryType, FileEntity, FileUploadPartEntity, FolderEntity, PaginationInfo};
 
 // Re-export all handlers for backward compatibility
 pub use admin::{
@@ -206,8 +206,9 @@ pub use messages::{
 pub use security::{ClickwrapHandler, GpgKeyHandler, IpAddressHandler, SftpHostKeyHandler};
 pub use sharing::{
     BundleActionHandler, BundleDownloadHandler, BundleHandler, BundleNotificationHandler,
-    BundleRecipientHandler, BundleRegistrationHandler, FormFieldSetHandler, InboxRecipientHandler,
-    InboxRegistrationHandler2, InboxUploadHandler, RequestHandler, ShareGroupHandler,
+    BundlePermission, BundleRecipientHandler, BundleRegistrationHandler, FormFieldSetHandler,
+    InboxRecipientHandler, InboxRegistrationHandler2, InboxUploadHandler, RequestHandler,
+    ShareGroupHandler,
 };
 pub use storage::{
     BandwidthSnapshotHandler, LockHandler, PriorityHandler, ProjectHandler,
@@ -216,8 +217,9 @@ pub use storage::{
 };
 pub use users::{
     ApiKeyCurrentHandler, ApiKeyHandler, CurrentUserHandler, GroupHandler, GroupUserHandler,
-    PermissionHandler, PublicKeyHandler, SessionHandler, SsoStrategyHandler, UserCipherUseHandler,
-    UserHandler, UserLifecycleRuleHandler, UserRequestHandler, UserSftpClientUseHandler,
+    PermissionHandler, PermissionType, PublicKeyHandler, SessionHandler, SsoStrategyHandler,
+    UserCipherUseHandler, UserHandler, UserLifecycleRuleHandler, UserRequestHandler,
+    UserSftpClientUseHandler,
 };
 
 // Error types are now in the error module

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,17 +25,17 @@ pub use crate::client::{FilesClient, FilesClientBuilder};
 pub use crate::error::{FilesError, Result};
 
 // Common entity types
-pub use crate::types::{FileEntity, FileUploadPartEntity, FolderEntity, PaginationInfo};
+pub use crate::types::{EntryType, FileEntity, FileUploadPartEntity, FolderEntity, PaginationInfo};
 
 // Progress tracking
 pub use crate::progress::{Progress, ProgressCallback};
 
 // Most commonly used handlers
 pub use crate::files::{FileActionHandler, FileHandler, FolderHandler};
-pub use crate::users::{ApiKeyHandler, GroupHandler, SessionHandler, UserHandler};
+pub use crate::users::{ApiKeyHandler, GroupHandler, PermissionType, SessionHandler, UserHandler};
 
 // Sharing
-pub use crate::sharing::{BundleHandler, RequestHandler};
+pub use crate::sharing::{BundleHandler, BundlePermission, RequestHandler};
 
 // Automation
 pub use crate::automation::{AutomationHandler, BehaviorHandler};

--- a/src/sharing/bundles.rs
+++ b/src/sharing/bundles.rs
@@ -15,7 +15,7 @@
 //! # Example
 //!
 //! ```no_run
-//! use files_sdk::{FilesClient, BundleHandler};
+//! use files_sdk::{FilesClient, BundleHandler, BundlePermission};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = FilesClient::builder()
@@ -34,7 +34,7 @@
 //!     Some("Internal sharing only"),
 //!     None,
 //!     Some(true),
-//!     Some("read")
+//!     Some(BundlePermission::Read)
 //! ).await?;
 //!
 //! println!("Share link: {}", bundle.url.unwrap_or_default());
@@ -54,7 +54,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 /// Bundle permissions enum
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BundlePermission {
     /// Read-only access
@@ -100,7 +100,7 @@ pub struct BundleEntity {
 
     /// Permissions that apply to folders in this share link
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub permissions: Option<String>,
+    pub permissions: Option<BundlePermission>,
 
     /// Preview only mode
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -357,7 +357,7 @@ impl BundleHandler {
     /// * `note` - Private internal note (not shown to recipients)
     /// * `code` - Custom URL code (auto-generated if not provided)
     /// * `require_registration` - Require recipients to register before access
-    /// * `permissions` - Access level: "read", "write", "read_write", "full", "preview_only"
+    /// * `permissions` - Access level (see [`BundlePermission`])
     ///
     /// # Returns
     ///
@@ -366,7 +366,7 @@ impl BundleHandler {
     /// # Example
     ///
     /// ```no_run
-    /// use files_sdk::{FilesClient, BundleHandler};
+    /// use files_sdk::{FilesClient, BundleHandler, BundlePermission};
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = FilesClient::builder().api_key("key").build()?;
@@ -382,7 +382,7 @@ impl BundleHandler {
     ///     None,
     ///     None,
     ///     Some(false),
-    ///     Some("read")
+    ///     Some(BundlePermission::Read)
     /// ).await?;
     ///
     /// println!("Share this link: {}", bundle.url.unwrap());
@@ -400,7 +400,7 @@ impl BundleHandler {
         note: Option<&str>,
         code: Option<&str>,
         require_registration: Option<bool>,
-        permissions: Option<&str>,
+        permissions: Option<BundlePermission>,
     ) -> Result<BundleEntity> {
         let mut body = json!({
             "paths": paths,

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,6 +7,32 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Type of a filesystem entry returned by Files.com.
+///
+/// The API reports each entry as either a `"file"` or a `"directory"`.
+/// Using an enum here instead of a raw string gives compile-time safety
+/// and exhaustive matching.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EntryType {
+    /// A regular file.
+    File,
+    /// A directory (folder).
+    Directory,
+}
+
+impl EntryType {
+    /// Returns `true` if this entry is a file.
+    pub fn is_file(&self) -> bool {
+        matches!(self, EntryType::File)
+    }
+
+    /// Returns `true` if this entry is a directory.
+    pub fn is_directory(&self) -> bool {
+        matches!(self, EntryType::Directory)
+    }
+}
+
 /// Represents a file or directory in Files.com
 ///
 /// This is the primary entity returned by most file operations.
@@ -20,9 +46,9 @@ pub struct FileEntity {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
 
-    /// Type: "file" or "directory"
+    /// Type: file or directory
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub file_type: Option<String>,
+    pub file_type: Option<EntryType>,
 
     /// Size in bytes
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -287,7 +313,7 @@ mod tests {
         let entity: FileEntity = serde_json::from_str(json).unwrap();
         assert_eq!(entity.path, Some("/test/file.txt".to_string()));
         assert_eq!(entity.display_name, Some("file.txt".to_string()));
-        assert_eq!(entity.file_type, Some("file".to_string()));
+        assert_eq!(entity.file_type, Some(EntryType::File));
         assert_eq!(entity.size, Some(1024));
     }
 

--- a/src/users/permissions.rs
+++ b/src/users/permissions.rs
@@ -7,7 +7,7 @@ use crate::{FilesClient, Result};
 use serde::{Deserialize, Serialize};
 
 /// Permission types available in Files.com
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PermissionType {
     /// List, preview, read, write, move, delete, rename, manage permissions
@@ -61,7 +61,7 @@ pub struct PermissionEntity {
 
     /// Permission type
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub permission: Option<String>,
+    pub permission: Option<PermissionType>,
 
     /// Apply to subfolders recursively
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -136,7 +136,7 @@ impl PermissionHandler {
     ///
     /// # Arguments
     /// * `path` - Folder path (required)
-    /// * `permission` - Permission type (admin, full, readonly, writeonly, list, history)
+    /// * `permission` - Permission type (see [`PermissionType`])
     /// * `user_id` - User ID (provide user_id or username)
     /// * `username` - Username (provide user_id or username)
     /// * `group_id` - Group ID (provide group_id or group_name)
@@ -149,7 +149,7 @@ impl PermissionHandler {
     pub async fn create(
         &self,
         path: &str,
-        permission: Option<&str>,
+        permission: Option<PermissionType>,
         user_id: Option<i64>,
         username: Option<&str>,
         group_id: Option<i64>,
@@ -159,7 +159,11 @@ impl PermissionHandler {
         let mut params = vec![("path", path.to_string())];
 
         if let Some(p) = permission {
-            params.push(("permission", p.to_string()));
+            // Serialize the enum through serde so the wire value stays the
+            // single source of truth (e.g. ReadonlySiteAdmin -> "readonly_site_admin").
+            if let serde_json::Value::String(s) = serde_json::to_value(&p)? {
+                params.push(("permission", s));
+            }
         }
         if let Some(uid) = user_id {
             params.push(("user_id", uid.to_string()));

--- a/tests/mock/sharing/bundles.rs
+++ b/tests/mock/sharing/bundles.rs
@@ -1,4 +1,4 @@
-use files_sdk::{BundleHandler, FilesClient};
+use files_sdk::{BundleHandler, BundlePermission, FilesClient};
 use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -169,7 +169,7 @@ async fn test_create_bundle_success() {
             None,
             Some("newbundle"),
             Some(true),
-            Some("read"),
+            Some(BundlePermission::Read),
         )
         .await
         .unwrap();

--- a/tests/mock/users/permissions.rs
+++ b/tests/mock/users/permissions.rs
@@ -1,4 +1,4 @@
-use files_sdk::{FilesClient, PermissionHandler};
+use files_sdk::{FilesClient, PermissionHandler, PermissionType};
 use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -44,7 +44,7 @@ async fn test_list_permissions_success() {
     assert_eq!(permissions.len(), 2);
     assert_eq!(permissions[0].id, Some(1));
     assert_eq!(permissions[0].path.as_deref(), Some("/documents"));
-    assert_eq!(permissions[0].permission.as_deref(), Some("full"));
+    assert_eq!(permissions[0].permission, Some(PermissionType::Full));
     assert_eq!(permissions[1].group_name.as_deref(), Some("Engineering"));
 }
 
@@ -107,7 +107,7 @@ async fn test_create_permission_for_user_success() {
     let permission = handler
         .create(
             "/documents",
-            Some("full"),
+            Some(PermissionType::Full),
             Some(123),
             None,
             None,
@@ -120,7 +120,7 @@ async fn test_create_permission_for_user_success() {
     assert_eq!(permission.id, Some(789));
     assert_eq!(permission.path.as_deref(), Some("/documents"));
     assert_eq!(permission.user_id, Some(123));
-    assert_eq!(permission.permission.as_deref(), Some("full"));
+    assert_eq!(permission.permission, Some(PermissionType::Full));
     assert_eq!(permission.recursive, Some(true));
 }
 
@@ -154,7 +154,7 @@ async fn test_create_permission_for_group_success() {
     let permission = handler
         .create(
             "/shared",
-            Some("readonly"),
+            Some(PermissionType::Readonly),
             None,
             None,
             Some(456),
@@ -166,7 +166,7 @@ async fn test_create_permission_for_group_success() {
 
     assert_eq!(permission.id, Some(790));
     assert_eq!(permission.group_id, Some(456));
-    assert_eq!(permission.permission.as_deref(), Some("readonly"));
+    assert_eq!(permission.permission, Some(PermissionType::Readonly));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Type-safety slice of #13: replace clearly closed-set stringly-typed fields in the
higher-level API with proper `enum`s (serde-tagged), mirroring the existing
`PermissionType` pattern in `src/users/permissions.rs`.

This is **part of #13** (a feedback dump). It deliberately does NOT close #13 --
only the Type Safety item is in scope here.

## Scope (this PR)

- Introduce enums for the closed-set fields the issue calls out (file/folder
  permissions, visibility, type) where they actually exist in the codebase.
- Mirror the established pattern: `#[derive(Debug, Clone, Serialize, Deserialize)]`
  + `#[serde(rename_all = "...")]`.
- Keep the build, clippy (`-D warnings`), tests, and examples green.

## Deferred (NOT in this PR -- remaining parts of #13)

- Progress callbacks coverage (note: `src/progress.rs` already exists -- audit/extend)
- Streaming upload/download via `AsyncRead`/`AsyncWrite` (note: `examples/streaming.rs` exists)
- Async operation traits (`Upload`/`Download`)

## How

Dispatched autonomously via `roba` working in an ephemeral clone + git worktree;
merged on green CI by the orchestrating session.
